### PR TITLE
FIX: use a boolean to toggle display of physical location for preconf

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -203,6 +203,7 @@ preconferenceRows:
  - {title: "Preconference #2", image: "no-photo-available.jpg", details: "Summary/Description"}
 
 # Preconference Location Block
+preconferenceLocationEnable: True
 preconferenceLocationBlockTitle: "Location"
 preconferenceLocationName: "Nationwide Hotel & Conference Center"
 preconferenceLocationLink: "https://www.nwhotelandconferencecenter.com/"

--- a/preconference.html
+++ b/preconference.html
@@ -8,6 +8,8 @@ permalink: /preconference/
 
  {% include about-preconference.html %}
 
- {% include preconference-location.html %}
+ {% if site.preconferenceLocationEnable == true %}
+  {% include preconference-location.html %}
+ {% endif %}
 
  {% include partners.html %}


### PR DESCRIPTION
This code adds a new boolean variable to `_config.yml` called `preconferenceLocationEnable`.

To test:
- Set `preconferenceLocationEnable` to `True`. Render site locally. Information for Nationwide Hotel and Conference Center should be shown on the preconference page .
- Set `preconferenceLocationEnable` to `False`. Render site locally. Location info should _not_ appear on the preconference page.

close #8 