### PR TITLE
Fix 'Development Only' Google Maps Watermark

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,10 +7,11 @@ plugins:
 - jekyll-sitemap
 safe: false
 
-#Google-Analytics
+#Google-Analytics & API Key
 googleAnalyticsTrackingId: "UA-**********"
 googleAnalyticsSiteUrl: "2020.alaoweb.org"
 siteVerification: ""
+googleMapsApiKey: "AIzaSyDUQZ2d8zeEcwzJur9Av9KSg2l1W1NNaH8"
 
 #Head
 metaKeywords: "event, alao, academic, libraries, ohio"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,12 +47,14 @@ layout: compress
     <script src="{{ "/js/default.js" | prepend: site.baseurl }}"></script>
     {% if page.permalink == '/' or page.permalink == '/preconference/' %}
     <script>
-        if ($(window).width() > 767) {
-            document.write('<script src="https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=false"><\/script>')
+         if ($(window).width() > 767) {
+            document.write('<script src="https://maps.googleapis.com/maps/api/js?v=3.exp&key={{ site.googleMapsApiKey }}"\n' +
+                'type="text/javascript"><\/script>')
         }
     </script>
     {% elsif page.permalink == '/logistics/' %}
-        <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places,geometry"></script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?v=3.exp&key={{ site.googleMapsApiKey }}&libraries=places,geometry"
+type="text/javascript"></script>
         <script type="text/javascript">
             var autoDirectionEnabled = {% if site.logisticsMapAutoDirections %} true {% else %} false {% endif %};
         </script>


### PR DESCRIPTION
This PR adds a variable for a Google Maps API key to `_config.yml` and updates the JavaScript API calls to use the new API key.

**Note:** As this API key has been published, the credentials are limited to only the Google Maps JavaScript API and the usable has been limited to HTTP Referrer of `2020.alaoweb.org/*`. As such, the maps will not display during local development, only on the published site. _Check the browser console for additional details during local development_

Closed #39 