### PR TITLE
Use MailChimp Audience to Capture Email Contacts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -261,7 +261,7 @@ statisticBlock:
 subscribeEnable: true
 subscribeImage: "speak-up.jpg"
 subscribeTitle: "Subscribe to ALAO Mailing List"
-subscribeAction: ""
+subscribeAction: "https://alaoweb.us10.list-manage.com/subscribe/post?u=ac241e268ddc3495466be87a8&amp;id=685009e39b"
 subscribeInfo: "Stay Informed of ALAO Events!"
 
 # -------------------------------------------------------------


### PR DESCRIPTION
Submitting an email address to subscribe to the ALAO mailing list from the conference site will post the email address to the ALAO MailChimp audience. MailChimp will reply with a subscription confirmation message upon addition.

I've confirmed that MailChimp audiences can be exported as a `.csv`

Closes #19 