### PR TITLE
Set of Minor Updates for CPC Meeting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -212,7 +212,7 @@ about these concerns can help promote authentic civility and collegiality in Nor
 reduce the factors that can cause employee mistreatment and misconduct in library workplaces."}
 
 # Preconference Location Block
-preconferenceLocationEnable: True
+preconferenceLocationEnable: False
 preconferenceLocationBlockTitle: "Location"
 preconferenceLocationName: "Nationwide Hotel & Conference Center"
 preconferenceLocationLink: "https://www.nwhotelandconferencecenter.com/"

--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -1,5 +1,4 @@
-- 
-  date: "2020-10-26"
+- date: "2020-10-26"
   dateReadable: "October 26"
   tracks: 
     - {title: "Track #1", color: "#90be4e"}
@@ -15,13 +14,13 @@
         endTime: "2:45",
         sessionIds: [002]
     }
-    - {
-    	startTime: "3:00",
-    	endTime: "4:45",
-    	sessionIds: [003]
-    }
-- 
-  date: "2020-10-27"
+#    - {
+#    	startTime: "3:00",
+#    	endTime: "4:45",
+#    	sessionIds: [003]
+#    }
+
+- date: "2020-10-27"
   dateReadable: "October 27"
   tracks: 
     - {title: "Track #1", color: "#90be4e"}

--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -2,7 +2,7 @@
   title: 'Business Meeting'
   description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Fermentum iaculis eu non diam. Risus feugiat in ante metus dictum at tempor commodo. Pellentesque id nibh tortor id aliquet lectus proin nibh. Mi in nulla posuere sollicitudin aliquam ultrices. Sit amet justo donec enim diam. Tellus id interdum velit laoreet id donec. Pharetra massa massa ultricies mi quis hendrerit. Cras fermentum odio eu feugiat pretium nibh ipsum consequat. Senectus et netus et malesuada fames. In mollis nunc sed id semper risus in. Varius morbi enim nunc faucibus. Dis parturient montes nascetur ridiculus mus mauris vitae. Tempus egestas sed sed risus pretium quam vulputate dignissim suspendisse. Egestas diam in arcu cursus euismod quis viverra. A iaculis at erat pellentesque. Pulvinar proin gravida hendrerit lectus. Tortor consequat id porta nibh venenatis cras sed felis. Elit duis tristique sollicitudin nibh sit amet commodo nulla facilisi. Nulla facilisi etiam dignissim diam.'
   subtype: presentation
-  speakers: [1, 2]
+  speakers: []
   language: en
   complexity: 'Beginner'
   presentation: 'https://www.example.com'
@@ -13,51 +13,57 @@
   video: '//www.youtube.com/embed/{replace_with_video_id}'
   question-time: '2020-10-26 10:20:00'
   question-link: 'https://us04web.zoom.us/j/76893733256?pwd=WHFqUkdJSnhBVEtmWE95RGhFSUpadz09'
+
 - id: 002
-  title: 'Preconference #1'
-  description: 'Prefconference #1 Description'
+  title: 'Renewal: Promoting Civility and Self-Care in (Academic) Libraries'
+  description: 'The Renewal Seminar offers a pathway for individuals to increase their awareness of the associated frameworks, development, outcomes, and emerging countermeasures of low morale, which is defined as repeated and protracted exposure to workplace abuse and neglect (Kendrick, 2017). Learning more about these concerns can help promote authentic civility and collegiality in North American libraries and reduce the factors that can cause employee mistreatment and misconduct in library workplaces.'
   subtype: workshop
-  speakers: []
+  speakers: [3]
   language: en
   complexity: 'Beginner'
   presentation: 'https://www.example.com'
   video: '//www.youtube.com/embed/{replace_with_video_id}'
-- id: 003
-  title: 'Preconference #2'
-  description: 'Preconference #2 Description'
-  subtype: workshop
-  speakers: []
-  language: en
-  complexity: 'Beginner'
-  presentation: 'https://www.example.com'
-  video: '//www.youtube.com/embed/{replace_with_video_id}'
+
+#- id: 003
+#  title: 'Preconference #2'
+#  description: 'Preconference #2 Description'
+#  subtype: workshop
+#  speakers: []
+#  language: en
+#  complexity: 'Beginner'
+#  presentation: 'https://www.example.com'
+#  video: '//www.youtube.com/embed/{replace_with_video_id}'
+
 - id: 101
   title: 'Keynote #1'
   description: 'Keynote #1 Description'
   subtype: keynote
-  speakers: [1]
+  speakers: [4]
   language: en
   complexity: 'Beginner'
   presentation: 'https://www.example.com'
   video: '//www.youtube.com/embed/{replace_with_video_id}'
+
 - id: 102
   title: 'Session #1'
   description: 'Description #1'
   subtype: keynote
-  speakers: [1]
+  speakers: [1, 2, 3, 4]
   language: en
   complexity: 'Beginner'
   presentation: 'https://www.example.com'
   video: '//www.youtube.com/embed/{replace_with_video_id}'
+
 - id: 103
   title: 'Session #2'
   description: 'Description #2'
   subtype: keynote
-  speakers: [1]
+  speakers: [1, 2, 3, 4]
   language: en
   complexity: 'Beginner'
   presentation: 'https://www.example.com'
   video: '//www.youtube.com/embed/{replace_with_video_id}'
+
 - id: 104
   title: 'Lunch'
   place: 'Location of your choosing'

--- a/_posts/2020-02-01-author-poster-title.markdown
+++ b/_posts/2020-02-01-author-poster-title.markdown
@@ -1,6 +1,6 @@
 ---
 layout: poster
-image: posters.jpg
+image: cod.png
 title: "Jekyll: Replacing LibGuides w/ a Static Site Generator"
 description: The simplicity of LibGuides revolutionized the way that librarians create web content for patrons. With this ease of use in content creation, the reduced need for librarians to continue to develop deep technical skills comes as a long-term cost. 
 date: 2020-01-01 08:00:00

--- a/posters.html
+++ b/posters.html
@@ -2,7 +2,7 @@
 layout: default
 title: Posters
 permalink: /posters/
-image: posters.jpg
+image: cod.png
 ---
 
  {% include top-section.html %}

--- a/preconference.html
+++ b/preconference.html
@@ -2,6 +2,7 @@
 layout: default
 title: Preconference
 permalink: /preconference/
+image: cod.png
 ---
 
  {% include top-section.html %}

--- a/schedule.html
+++ b/schedule.html
@@ -2,7 +2,7 @@
 layout: default
 title: Event schedule
 permalink: /schedule/
-image: schedule.jpg
+image: cod.png
 ---
 
 {% include top-section.html %}

--- a/speakers.html
+++ b/speakers.html
@@ -3,6 +3,7 @@ layout: default
 title: Speakers
 permalink: /speakers/
 modal: all
+image: cod.png
 ---
 
 {% include top-section.html %}

--- a/team.html
+++ b/team.html
@@ -2,7 +2,7 @@
 layout: default
 title: Team
 permalink: /team/
-color: "#00bcd4"
+image: cod.png
 modal: team
 ---
 


### PR DESCRIPTION
This PR contains a set of minor updates to:
- universally use an abstract background in the top-section of each site page
- update the pre-conference description on the schedule
- update the schedule with most recent info
- disable physical location map for the pre-conference
- remove second pre-conference from schedule

We will likely modify some of these elements as time goes on, but I want to get the site into a reasonable - and slightly more cohesive - deployable state. 