### PR TITLE
unpublished bogus posters

### DIFF
--- a/_posts/2020-02-01-author-poster-title.markdown
+++ b/_posts/2020-02-01-author-poster-title.markdown
@@ -11,6 +11,7 @@ presenters:
     }
 video: '//www.youtube.com/embed/Jdv2Wp9MzY0'
 isStaticPost: true
+published: false
 ---
 
 Template for Poster Sessions

--- a/_posts/2020-06-23-gale-collaboration.md
+++ b/_posts/2020-06-23-gale-collaboration.md
@@ -18,4 +18,5 @@ presenters:
     }
 video: '//www.youtube.com/embed/aopdD9Cu-So'
 isStaticPost: true
+published: false
 ---


### PR DESCRIPTION
added "published: false" to bogus poster sessions to remove them from displaying in the session search