### PR TITLE
Pluralize preconference(s) in headers and menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -167,7 +167,7 @@ directionDetailsWideCards:
 # -------------------------------------------------------------
 navigationLinks:
  - {permalink: "/", text: "Home"}
- - {permalink: "/preconference/", text: "Preconference"}
+ - {permalink: "/preconference/", text: "Preconferences"}
  - {permalink: "/schedule/", text: "Schedule"}
  - {permalink: "/speakers/", text: "Speakers"}
  - {permalink: "/posters/", text: "Posters"}

--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ permalink: "/posters/:title"
 aboutTitle: "ALAO Virtual Conference"
 aboutBlock:
  - {title: "Sessions", image: "sessions.jpg", text: "Prerecorded traditional presentations with live Q&A" }
- - {title: "Pre-Conference", image: "preconference.jpg", text: "An opportunity for a deeper dive into a single topic in a workshop format" }
+ - {title: "Pre-Conferences", image: "preconference.jpg", text: "An opportunity for a deeper dive into a single topic in a workshop format" }
  - {title: "Posters", image: "posters.jpg", text: "Short videos with asynchronous, text-based Q&A" }
  - {title: "Networking", image: "networking.jpg", text: "Opportunities to connect with other attendees in a less formal structure"}
 

--- a/preconference.html
+++ b/preconference.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Preconference
+title: Preconferences
 permalink: /preconference/
 image: waves-background.svg
 ---
@@ -10,7 +10,7 @@ image: waves-background.svg
 {% include about-preconference2.html %}
 
 {% if site.preconferenceLocationEnable == true %}
-    {% include preconference-location.html %}
+{% include preconference-location.html %}
 {% endif %}
 
 {% include sponsors.html %}


### PR DESCRIPTION
* main menu
* in the image block on the front page
* in the page header & title for the preconf page
* closes #127 

### To test: 
https://2020-staging.alaoweb.org/preconference/
