### PR TITLE
FIX: stabilzes top-section SVG background

### DIFF
--- a/_includes/top-section-posters.html
+++ b/_includes/top-section-posters.html
@@ -1,5 +1,5 @@
 <!-- Begin Top Section Posters -->
-<section id="top-section" class="top-section image-section {% if page.image %}enable-overlay{% endif %}" style="background-image: url('{{ site.baseurl }}/img/sections-background/{{ site.postersBackground }}');">
+<section id="top-section" class="top-section image-section enable-overlay" style="background-image: url('{{ site.baseurl }}/img/sections-background/{{ site.postersBackground }}');">
     <div class="overlay gradient-overlay"></div>
 
     {% include navigation.html %}


### PR DESCRIPTION
Several weeks ago, it was decided to use a common SVG background for all posters and set that background value in `_config.yml` as `postersBackground: waves-background.svg`, rather than in each poster's front matter.

This PR ensures that the `enable-overlay` class is uniformly applied to each poster's template, by removing the logic that check for an `image: background.file` in each poster before applying the overlay.

Closes #134 