### PR TITLE
Add faces to poster list in session-search

### DIFF
--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -202,7 +202,7 @@
   name: 'Catie'
   surname: 'Carlson'
   pronouns: 'she/her/hers'
-  company: 'University of Cincinnati Clermont College'
+  company: 'University of Cincinnati Clermont'
   title: 'Library Director'
   bio: 'Catie Carlson is the Library Director at the University of Cincinnati Clermont College. She previously worked at Tiffin University as the Library Director during their general education curriculum revision. She holds a an MLIS, MEd, and is currently enrolled in a doctoral program for Adult Learning & Leadership.'
   thumbnailUrl: no_image.png
@@ -252,7 +252,7 @@
   name: 'Malachai'
   surname: 'Darling'
   pronouns: 'he/him/his'
-  company:
+  company: 'Indiana University-Bloomington'
   title:
   bio: "Malachai Darling is a recent graduate from Indiana University with a master's degree in Library Science and a specialization in Archives and Records Management. He has an interest in public services within archives and special collections and finds projects such as that described in the abstract allows him to grow and develop skills that better assist researchers in any institution."
   thumbnailUrl: no_image.png
@@ -786,4 +786,24 @@
   title: 'Copyright Librarian and Contracting Specialist'
   bio:
   thumbnailUrl: sandra_enimil.png
+  rockstar: false
+
+- id: 77
+  name: 'Matt'
+  surname: 'Benzing'
+  pronouns:
+  company: 'Miami University'
+  title: 'Computing and Engineering Librarian'
+  bio:
+  thumbnailUrl: no_image.png
+  rockstar: false
+
+- id: 77
+  name: 'Lisa'
+  surname: 'Hayes'
+  pronouns:
+  company: 'Indiana Wesleyan University'
+  title: 'OCLS Librarian'
+  bio:
+  thumbnailUrl: no_image.png
   rockstar: false

--- a/_includes/session-search.html
+++ b/_includes/session-search.html
@@ -76,11 +76,11 @@
           {% for id in session.speaker-data %}
           {% assign this-person = site.data.speakers | where: 'id', id %}
           {% assign speakers = speakers |
-              append: '<div class="speaker-block poster-speaker"><!--div class="speaker-img flow-img img-circle" style="background-image: url(/img/people/)"></div---> 
-              <p class="speaker-name"><span class="name-only">' | append: this-person[0].name | append: ' ' | append: this-person[0].surname | append: '</span><span class="speaker-position">' | append: this-person[0].company | append: '</span
-                >' | append: '
-              </div></div>
-              ' %}
+            append: '<div class="speaker-block"><div class="speaker-img flow-img img-circle" style="background-image: url(/img/people/'  | append: this-person[0].thumbnailUrl |append:')"></div> 
+            <p class="speaker-name"><span class="name-only">' | append: this-person[0].name | append: ' ' | append: this-person[0].surname | append: '</span><span class="speaker-position">' | append: this-person[0].company | append: '</span
+              ></p></div>
+            ' %}
+
           {% endfor %}
           {% else %}
           {% for

--- a/_includes/session-search.html
+++ b/_includes/session-search.html
@@ -66,13 +66,31 @@
           {% endfor %}
 
           <!-- posters -->
-          {% for session in site.posts %} {% assign speakers = "" %} {% for
-          person in session.presenters %} {% assign speakers = speakers |
-          append: '<div class="speaker-block poster-speaker"><!--div class="speaker-img flow-img img-circle" style="background-image: url(/img/people/)"></div---> 
-          <p class="speaker-name"><span class="name-only">' | append: person.name | append: '</span><span class="speaker-position">' | append: person.institution | append: '</span
-            >' | append: '
-          </div></div>
-          ' %}
+          {% for session in site.posts %} {% assign speakers = "" %}
+
+
+          {% if session.speaker-data %}
+          {% comment %}
+          Using speaker-data is the new way
+          {% endcomment %}
+          {% for id in session.speaker-data %}
+          {% assign this-person = site.data.speakers | where: 'id', id %}
+          {% assign speakers = speakers |
+              append: '<div class="speaker-block poster-speaker"><!--div class="speaker-img flow-img img-circle" style="background-image: url(/img/people/)"></div---> 
+              <p class="speaker-name"><span class="name-only">' | append: this-person[0].name | append: ' ' | append: this-person[0].surname | append: '</span><span class="speaker-position">' | append: this-person[0].company | append: '</span
+                >' | append: '
+              </div></div>
+              ' %}
+          {% endfor %}
+          {% else %}
+          {% for
+            person in session.presenters %} {% assign speakers = speakers |
+            append: '<div class="speaker-block poster-speaker"><!--div class="speaker-img flow-img img-circle" style="background-image: url(/img/people/)"></div---> 
+            <p class="speaker-name"><span class="name-only">' | append: person.name | append: '</span><span class="speaker-position">' | append: person.institution | append: '</span
+              >' | append: '
+            </div></div>
+            ' %}
+          {% endif %}
 
           {% endfor %}
           <tr id="poster-{{session.id | remove: '/'}}" class="slot"

--- a/_includes/session-search.html
+++ b/_includes/session-search.html
@@ -90,9 +90,10 @@
               >' | append: '
             </div></div>
             ' %}
+          {% endfor %}
           {% endif %}
 
-          {% endfor %}
+
           <tr id="poster-{{session.id | remove: '/'}}" class="slot"
             data-toggle="modal"
             data-target="#posterDetail-{{session.id | remove: '/'}}">

--- a/_includes/session-search.html
+++ b/_includes/session-search.html
@@ -75,12 +75,20 @@
           {% endcomment %}
           {% for id in session.speaker-data %}
           {% assign this-person = site.data.speakers | where: 'id', id %}
+          {% if this-person[0].thumbnailUrl != "no_image.png" %}
           {% assign speakers = speakers |
             append: '<div class="speaker-block"><div class="speaker-img flow-img img-circle" style="background-image: url(/img/people/'  | append: this-person[0].thumbnailUrl |append:')"></div> 
             <p class="speaker-name"><span class="name-only">' | append: this-person[0].name | append: ' ' | append: this-person[0].surname | append: '</span><span class="speaker-position">' | append: this-person[0].company | append: '</span
               ></p></div>
             ' %}
-
+          {% else %}
+          {% assign speakers = speakers |
+            append: '<div class="speaker-block poster-speaker"><!--div class="speaker-img flow-img img-circle" style="background-image: url(/img/people/)"></div---> 
+            <p class="speaker-name"><span class="name-only">' | append: this-person[0].name | append: ' ' | append: this-person[0].surname | append: '</span><span class="speaker-position">' | append: this-person[0].company | append: '</span
+              >' | append: '
+            </div></div>
+            ' %}
+          {% endif %}
           {% endfor %}
           {% else %}
           {% for

--- a/_posts/2020-07-01-alumni-engagement.md
+++ b/_posts/2020-07-01-alumni-engagement.md
@@ -1,25 +1,26 @@
 ---
 layout: poster
-title: "Connecting the Past to the Present: Alumni Engagement with the Library During Homecoming"
-description: "Our library has implemented a plan to sustain alumni engagement with the library and its resources during Homecoming festivities. In 2019, we developed open-source software to pair yearbook photos with selfies or photos from “today” to create social-media-ready now-and-then images alums could share. We also highlighted special collections related to the 50th anniversary year being celebrated and made old yearbooks available. Paired with some basic hospitality (snacks, shelter from the weather, the big game on a live feed, etc), we highlighted the library’s alumni-oriented resources and deepened our partnership with the Alumni Relations office. We will share some easy things your library can do to bring alumni to the library during Homecoming and similar events, and share resources to support some more involved projects to engage with alums. We will also share the open-source software we developed to create “now-and-then” alumni photos for social media."
+title: 'Connecting the Past to the Present: Alumni Engagement with the Library During Homecoming'
+description: 'Our library has implemented a plan to sustain alumni engagement with the library and its resources during Homecoming festivities. In 2019, we developed open-source software to pair yearbook photos with selfies or photos from “today” to create social-media-ready now-and-then images alums could share. We also highlighted special collections related to the 50th anniversary year being celebrated and made old yearbooks available. Paired with some basic hospitality (snacks, shelter from the weather, the big game on a live feed, etc), we highlighted the library’s alumni-oriented resources and deepened our partnership with the Alumni Relations office. We will share some easy things your library can do to bring alumni to the library during Homecoming and similar events, and share resources to support some more involved projects to engage with alums. We will also share the open-source software we developed to create “now-and-then” alumni photos for social media.'
 date: 2020-07-01 08:00:00
+speaker-data: [41, 51, 57]
 presenters:
   - {
       name: Ken Irwin,
       bio: Ken Irwin is a Web Services Librarian at Miami University. He is interested in developing open-source solutions to solve challenging library issues and to make the most of our resources.,
-      institution: Miami University
+      institution: Miami University,
     }
   - {
       name: Kristen Peters,
       bio: Kristen Peters is a Reference Librarian at Wittenberg University. She is always on the lookout for new ways the library faculty and staff can form new connections that support lifelong learning.,
-      institution: Wittenberg University
+      institution: Wittenberg University,
     }
   - {
-    name: Alisa Mizikar,
-    bio: Alisa Mizikar is a Reference Librarian at Wittenberg University. She is interested in building community and making the library a welcoming place for everyone.,
-    institution: Wittenberg University
+      name: Alisa Mizikar,
+      bio: Alisa Mizikar is a Reference Librarian at Wittenberg University. She is interested in building community and making the library a welcoming place for everyone.,
+      institution: Wittenberg University,
     }
-video: "//www.youtube.com/embed/{video-is}"
+video: '//www.youtube.com/embed/{video-is}'
 isStaticPost: false
 published: true
 ---

--- a/_posts/2020-07-01-bracketology.md
+++ b/_posts/2020-07-01-bracketology.md
@@ -3,6 +3,7 @@ layout: poster
 title: "June Madness! A Month of Book Bracketology"
 description: "Offering support in a remote learning environment has long been an essential function of libraries. As universities across the country moved to digital spaces for engagement as well as education, libraries followed suit. June Madness! is a piece of passive programming offered by this academic library. Utilizing both Libwizard and Libguides, librarians were able to create a program which mirrored the traditional NCAA March Madness Bracket, using books from the library and OhioLINK catalogs to represent four areas unique to this campus. June Madness! offered students the opportunity to interact with their library, voice their opinions, and predict winners on their own time, allowing them to learn about lending services at their own pace. Coordinated marketing of the program to university faculty, staff, alumni, and students showcased the library as a digital space not only for distance learning, but for fun and engagement as well."
 date: 2020-07-01 08:00:00
+speaker-data: [45, 71, 32]
 presenters:
   - {
       name: Zachary Lewis,

--- a/_posts/2020-07-01-critical-info-lit.md
+++ b/_posts/2020-07-01-critical-info-lit.md
@@ -3,6 +3,7 @@ layout: poster
 title: "Libraries are not neutral: Implementing social justice and critical information literacy into one-shot instruction"
 description: "The United States is finally listening to the Black Lives Matter Movement. After the tragic murders of George Floyd, Breonna Taylor, and far too many others at the hands of police, white Americans are recognizing the systemic racism inherent in our culture and systems. However, it’s not enough to merely acknowledge systemic racism, we need to work to dismantle racist power narratives. How can we as librarians, an overwhelming white profession, begin to do this necessary work in the classroom?<br/><br/>This poster will serve two main functions. First, it will discuss how social justice relates to the ACRL Framework for Information Literacy, notably in the frames Authority is Constructed and Contextual, Information has Value, and Scholarship as Conversation. It will also detail the arguments of librarians who have criticized the frames for not taking a strong enough stance on social justice issues.<br/><br/>Next, this poster will explore various ways social justice can be integrated into one-shot library instruction through critical information literacy. The ideas presented will be applicable to social justice as it pertains to race, gender, or sexual orientation. Attendees will have concrete ideas for how they can implement social justice work into their one-shots after viewing the poster."
 date: 2020-07-01 08:00:00
+speaker-data: [37]
 presenters:
   - {
       name: Stefanie Hilles,

--- a/_posts/2020-07-01-digital-initiative-workflows.md
+++ b/_posts/2020-07-01-digital-initiative-workflows.md
@@ -3,6 +3,7 @@ layout: poster
 title: "Sustainable Digital Initiative Workflows"
 description: "Managing digital initiatives with limited staff can be challenging. Learn how a mid-sized university applied technical services librarians’ metadata expertise, liaison librarians’ relationships with faculty and knowledge of subject areas, and systems staffs’ technical expertise to make the process more efficient and sustainable. Find out how interdepartmental collaboration and implementation of time-saving scripts and free tools worked well and where there are still opportunities for improvement."
 date: 2020-07-01 08:00:00
+speaker-data: [49]
 presenters:
   - {
       name: Marsha Miles,

--- a/_posts/2020-07-01-diversity-dialogues.md
+++ b/_posts/2020-07-01-diversity-dialogues.md
@@ -3,6 +3,7 @@ layout: poster
 title: "Engaging Library Staff in Diversity Dialogues: Experiences from a Small PWI Institution"
 description: "During the 2019-2020 academic year, we started an EDI focused reading and discussion program for all library employees at our small, predominately white institution. The program was intended to raise awareness about issues related to EDI, provide a safe space for staff to have challenging discussions, and to identify practical steps that library employees could undertake in order to support the University’s commitment to non-discrimination and diversity. In support of these goals we selected readings on a variety of topics related to diversity, made use of multiple discussion models, and designed our year-end staff retreat to serve as a culmination for our first year of discussions."
 date: 2020-07-01 08:00:00
+speaker-data: [30, 7]
 presenters:
   - {
       name: Matt Francis,

--- a/_posts/2020-07-01-hs-location.md
+++ b/_posts/2020-07-01-hs-location.md
@@ -3,6 +3,7 @@ layout: poster
 title: "Effects of high school location on first-year students’ research confidence and college readiness"
 description: "In Ohio, K-12 public school funding models have been ruled unconstitutional four times due to the great discrepancies among districts from different economic and geographic areas. One of these discrepancies is often the availability of library services. In our research, we aimed to examine how these discrepancies may have altered preparedness for college-level research for incoming first-year students from various backgrounds. As the 2019-20 school year opened, we surveyed the incoming first-year class at a large public university. We received 117 responses in total from this survey. We first looked at this population as a whole, then analyzed responses by rural/urban/suburban areas. We found that students from rural districts were frequently taught how to conduct research by someone other than a school librarian. We also found significant differences in student confidence between students taught by librarians in high school and students taught by others. As students are now expected to learn remotely, at least part-time, potentially without the support from access to the library and library staff on campus, this research helps clarify the challenges students face in their home communities."
 date: 2020-07-01 08:00:00
+speaker-data: [52, 73, 77]
 presenters:
   - {
       name: Abi Morgan,

--- a/_posts/2020-07-01-info-lit-gen-ed.md
+++ b/_posts/2020-07-01-info-lit-gen-ed.md
@@ -3,6 +3,7 @@ layout: poster
 title: "Information Literacy in General Education"
 description: "In a multi-year process, an entire general education curriculum was revised. Through this revision, the curriculum went from a subject-focused list to one that highly emphasizes critical thinking, problem-solving, and analysis. The library was fortunate to be involved throughout this revision working with faculty for a comprehensive 4-year curriculum. We will explore the ways in which the library was involved and what the resulting curriculum became, including information on key takeaways regarding delivery in two modalities (classroom-based and online). We will also explain how this impacted library resources and services in the curriculum’s first year and what its future may be."
 date: 2020-07-01 08:00:00
+speaker-data: [18, 27]
 presenters:
   - {
       name: Catie Carlson,

--- a/_posts/2020-07-01-libcal-to-circulate.md
+++ b/_posts/2020-07-01-libcal-to-circulate.md
@@ -3,6 +3,7 @@ layout: poster
 title: "Making the Most of a Scarce Resource: Leveraging LibCal to Circulate Adobe Software Licenses"
 description: "Adobe (Photoshop, Illustrator, Creative Cloud, etc.) licenses are expensive and many institutions have to ration access to them. But many users are eager for access to their powerful software, and often need access only for a short time. Using open-source software that we will share with you, we use the Adobe User Management API to turn Adobe licenses on and off for users who reserve access to the software using LibCal’s “Equipment Checkout” feature. If a license is available (not checked out), users can get short-term access to the software almost instantaneously and without direct intervention by library staff. This lets us maintain an affordable number of licenses and legally and efficiently share them among students, faculty, and staff. This open source solution can also be used with other licenses that can be managed by an API."
 date: 2020-07-01 08:00:00
+speaker-data: [41, 14]
 presenters:
   - {
       name: Ken Irwin,

--- a/_posts/2020-07-01-marketable-skills.md
+++ b/_posts/2020-07-01-marketable-skills.md
@@ -3,6 +3,7 @@ layout: poster
 title: "Molding Marketable Skills out of Mentee Interests"
 description: "College at all levels is an opportunity for students to learn and grow as professionals. Frequently, this is growth happens in jobs that provide real world experience, rather than in the classroom. However, the opportunity to grow and develop skills beyond routine work tasks and the classroom assignments are overlooked.<br/><br/>All students find something that pulls at their curiosity and gets them excited about the work they hope to do. It is responsibility of their mentors to notice this excitement and encourage their pursuits in a productive way. Enabling students to pursue personal projects helps them develop marketable skills and molds them into better professionals as the enter the job market. As they do projects motivated by personal interests, they develop talking points and stories that can be translated into cover letters and real-world job skills. This could be familiarizing themselves with the IRB process or exploring the broader implications or career relevance of topics covered in class. The mentor should be interested, express confidence, be a sounding board, and support students to take the next step in their project.<br/><br/>This poster will explore the steps the librarian mentors should take to support student worker mentees’ interests and personal projects."
 date: 2020-07-01 08:00:00
+speaker-data: [31, 23]
 presenters:
   - {
       name: Madeleine Gaiser,

--- a/_posts/2020-07-01-mindfulness.md
+++ b/_posts/2020-07-01-mindfulness.md
@@ -3,6 +3,7 @@ layout: poster
 title: "Evolution of a Mindfulness Based Stress Relief Program for the Community College Campus"
 description: "Although not mainstream in academic settings, recent studies have indicated the value of mindfulness activities on student performance, behavior, and resilience (e.g. Lin and Mai, 2018; Vidic and Cherup, 2019). We recognized the need for mindfulness practices among our stressed community college students who are routinely tasked with juggling academic obligations and personal barriers. Providing snacks and space simply was not enough support. To address this need, we expanded upon an inherited stress relief program delivered to students twice each semester. We built in a foundation of mindfulness activities, including meditation and therapy dog sessions. We continue to add experimental passive and active mindfulness options designed to capture the attention of a very diverse body of students. The result is a work in progress, but one that has enabled us to form lasting connections and initiate greater opportunities for the library to provide mindfulness services across campus. Utilizing a poster presentation format, we wish to demonstrate to conference attendees a method and examples by which to establish an intentional mindfulness-based stress relief program. We will emphasize leveraging of existing resources, including mindfulness skills, interests, and campus relationships of academic library staff."
 date: 2020-07-01 08:00:00
+speaker-data: [47, 66]
 presenters:
   - {
     name: Megan Mamolen,

--- a/_posts/2020-07-01-mini-conference.md
+++ b/_posts/2020-07-01-mini-conference.md
@@ -3,6 +3,7 @@ layout: poster
 title: "Sustainable, Cooperative Instruction: Implementing a One-Shot Mini-Conference"
 description: "This poster will describe a cooperative effort between archivists, an instruction librarian, our faculty partner, and an undergraduate teaching assistant to support a particularly challenging research assignment in a course that regularly enrolls 50-60 students from a variety of majors. At the request of our faculty partner, we designed a one-shot “mini-conference” that fit within a standard course block and was composed of repeated concurrent workshops. Each workshop focused on a particular source or genre of sources and the advanced search strategies used to navigate them. As such, the instruction aligned well with ACRL’s information literacy frame searching as strategic exploration. Instructors found this format to be sustainable and scalable in part because we were able to provide specialized instruction in a more intimate setting than generally possible for larger class sizes. The poster will offer practical advice for replicating the mini-conference and highlight the benefits of this format. While many libraries may not have the space or staff to replicate the model in-person, it could be modified for synchronous or asynchronous online instruction."
 date: 2020-07-01 08:00:00
+speaker-data: [8, 15]
 presenters:
   - {
       name: Maureen Barry,

--- a/_posts/2020-07-01-no-login-needed.md
+++ b/_posts/2020-07-01-no-login-needed.md
@@ -3,6 +3,7 @@ layout: poster
 title: "No Login Needed: Developing a New Library Website on Your Own"
 description: "This poster focuses on the development of a new academic library website at a small private university, following a sudden shift to a new university website model. At the beginning of the Fall 2019 semester, the University moved to a new website model that separated its existing website into two: an internal website for current members of the University, and an external website for users outside of the university. Due to this shift almost all of the undergraduate library’s content was placed behind a login barrier on the internal website, which extended the research and information gathering process for current members of the University, and prevented users and researchers from outside the University from accessing it. After discussions with necessary stakeholders and upper administration, it was decided that the undergraduate library would create and manage its own website. This poster chronicles the development and implementation of the new website by a single librarian, and showcases the major issues the librarian tackled during the website’s development."
 date: 2020-07-01 08:00:00
+speaker-data: [24]
 presenters:
   - {
       name: Chris Deems,

--- a/_posts/2020-07-01-oa-consultancy-service.md
+++ b/_posts/2020-07-01-oa-consultancy-service.md
@@ -3,6 +3,7 @@ layout: poster
 title: "No Publishing Services? No Problem!: Growing a Consultancy Service for OA Journal Editors"
 description: "Through liaison activities, librarians identified faculty editors of locally-published open access scholarly journals needing journal management support, as well as guidance in enhancing the scholarly impact and perceived value of publications among research community stakeholders. Faculty editors of these publications are often unaware of the strategies available to increase the potential for the success of their journals and do not consider libraries as a source for support. This state of affairs represents a tremendous service opportunity for academic libraries, especially those that cannot offer full, standalone publishing services. Assembling a small, in-house team with relevant expertise, librarians were able to provide high-value, game-changing consultancy services where faculty-editors came to view librarians as full partners in enhancing scholarly communications. This poster highlights the evolution of this innovative and sustainable consultancy service model to support faculty editors."
 date: 2020-07-01 08:00:00
+speaker-data: [67, 26]
 presenters:
   - {
       name: Daniela Solomon,

--- a/_posts/2020-07-01-pandemic-student-services.md
+++ b/_posts/2020-07-01-pandemic-student-services.md
@@ -3,6 +3,7 @@ layout: poster
 title: "Responding to Covid: Serving Students in the Pandemic"
 description: "Poster will show the innovations of the Off Campus Library Services team during the Covid pandemic. New services, new approaches, new ways of delivering services will all be covered."
 date: 2020-07-01 08:00:00
+speaker-data: [77]
 presenters:
   - {
       name: Lisa Hayes,

--- a/_posts/2020-07-01-safe-space.md
+++ b/_posts/2020-07-01-safe-space.md
@@ -3,6 +3,7 @@ layout: poster
 title: "Where do we belong? Student thoughts about the Library as a Safe Space"
 description: "Looking for ways to understand and better serve the changing demographic of your student body? This poster session will share focus group results from students of minority communities asking what factors define a Safe Space. A greater understanding of these factors will assist libraries in working toward the goal of inclusivity and openness, a common mission among many college and university libraries. Data presented will include graphics, models, and suggestions for how libraries could use these results to adapt spaces and services. See the visualized responses and learn to conduct a similar study at your library. Main takeaways include positive and negative interactions in library spaces, ideas for new services and/or spaces, and library services reported to be the most important to our students."
 date: 2020-07-01 08:00:00
+speaker-data: [21, 20, 61]
 presenters:
   - {
       name: Jess Crossfield McIntosh,

--- a/_posts/2020-07-01-social-justice.md
+++ b/_posts/2020-07-01-social-justice.md
@@ -3,6 +3,7 @@ layout: poster
 title: "LibGuides for Social Justice: Transformative or Transactional?"
 description: "The use of the LibGuides platform to provide access to information and resources outside the scope of traditional subject and course guides is a direct example of how libraries and librarians are using their tools to become advocates and allies for change. In this poster presentation, I explore LibGuides that were created in conversation with the Black Lives Matter, anti-racism movements and police brutality dialogues happening in our country, highlighting the need to think critically about our motivations and implementations of social justice guides."
 date: 2020-07-01 08:00:00
+speaker-data: [58]
 presenters:
   - {
       name: Stephanie Porrata,

--- a/_posts/2020-07-01-sustainable-library-instruction.md
+++ b/_posts/2020-07-01-sustainable-library-instruction.md
@@ -6,6 +6,7 @@ So, I wanted to create sustainable online library instruction and a flexible lea
 This is my attempt to create zero cost online library instruction (my example is RefWorks online workshop) by using Google Course Builder and ShareX. Google Course Builder and ShareX are both free. You will need to install C# compiler and Python in order to use Google Course Builder, but you don’t need any programming experience. And I will explain how to install C# and Python, and share all tips I learned from using the free but sometimes quirky software.
 "
 date: 2020-07-01 08:00:00
+speaker-data: [38]
 presenters:
   - {
       name: Yuimi Hlasten,

--- a/_posts/2020-07-01-transitioning-library-services.md
+++ b/_posts/2020-07-01-transitioning-library-services.md
@@ -3,6 +3,7 @@ layout: poster
 title: "Transitioning Library Services Online During the COVID19 Pandemic"
 description: "This poster session will discuss the steps taken to transition library services to a completely online format during the COVID19 pandemic. Specifically, the poster will describe how reference transactions were quickly moved into the Skype for Business environment in order to be in line with communication technology decisions utilized for student and faculty communication. The poster will then describe how continuing education in the form of online discussion forums and online conferences was utilized to quickly discover best practices for library administration and operations during state-wide quarantine. The poster will then describe how technical services and collection development activities were adjusted to leverage existing digital collections and increase digital holdings. The poster will then describe how virtual outreach is utilized in the form of classroom visits via Skype and mass student emails to provide information literacy instruction and make students and faculty aware of virtual library resources and services."
 date: 2020-07-01 08:00:00
+speaker-data: [25]
 presenters:
   - {
       name: Joseph Dudley,

--- a/_posts/2020-07-01-work-from-home.md
+++ b/_posts/2020-07-01-work-from-home.md
@@ -1,15 +1,27 @@
 ---
 layout: poster
-title: "Keeping On: Maintaining Clear and Consistent Communication with Staff during a COVID-19 Work From Home Situation"
-description: "The COVID-19 pandemic led many academic libraries to close for several months in Spring and Summer 2020. This case study will share the experiences of one institution in maintaining contact with staff on Work from Home status as they worked independently to complete work assignments; in some cases, when employees’ primary work involved public service, the work assignments were not a part of their daily routine prior to the Work-from-Home status.<br/><br/>This session will share experiences in monitoring workflow, answering questions, maintaining morale and a sense of community among employees working in isolation, and sharing information about the resumption of in-person library services, including curbside pickup and eventual reopening of library facilities. NOTE: In Fall 2019, this institution plans to separate staff into two separate schedules, each of which will work alternating work-from-home and in-person shifts, in order to minimize physical contact and the risk of COVID-19."
+title: 'Keeping On: Maintaining Clear and Consistent Communication with Staff during a COVID-19 Work From Home Situation'
+description: 'The COVID-19 pandemic led many academic libraries to close for several months in Spring and Summer 2020. This case study will share the experiences of one institution in maintaining contact with staff on Work from Home status as they worked independently to complete work assignments; in some cases, when employees’ primary work involved public service, the work assignments were not a part of their daily routine prior to the Work-from-Home status.<br/><br/>This session will share experiences in monitoring workflow, answering questions, maintaining morale and a sense of community among employees working in isolation, and sharing information about the resumption of in-person library services, including curbside pickup and eventual reopening of library facilities. NOTE: In Fall 2019, this institution plans to separate staff into two separate schedules, each of which will work alternating work-from-home and in-person shifts, in order to minimize physical contact and the risk of COVID-19.'
 date: 2020-07-01 08:00:00
+speaker-data: [72]
 presenters:
   - {
       name: Rob O'Brien Withers,
-      bio: Withers is Coordinator of Access Services at Miami University. He has presented at conferences including the Access Services Conference, ACRL, Brick and Click, Computers in Libraries, HighEdWeb, LOEX, and NASIG and published in Against the Grain, College & Research Libraries, C&RL News, Library Collections, Acquisitions and Technical Services, and College & Undergraduate Libraries.,
-      institution: Miami University
+      bio: Withers is Coordinator of Access Services at Miami University. He has presented at conferences including the Access Services Conference,
+      ACRL,
+      Brick and Click,
+      Computers in Libraries,
+      HighEdWeb,
+      LOEX,
+      and NASIG and published in Against the Grain,
+      College & Research Libraries,
+      C&RL News,
+      Library Collections,
+      Acquisitions and Technical Services,
+      and College & Undergraduate Libraries.,
+      institution: Miami University,
     }
-video: "//www.youtube.com/embed/{video-is}"
+video: '//www.youtube.com/embed/{video-is}'
 isStaticPost: false
 published: true
 ---


### PR DESCRIPTION
Right now, the data structure in posts (posters) doesn't include a link to the speakers.yml file, so it doesn't have access to speaker images. This PR adds a backwardly compatible upgrade. We can add a `speaker-data` parameter to posts, e.g.: `speaker-data: [3,5,9]`. If speaker-data is used, it overrides the inline `presenters` parameter with content from the speakers.yml file. 

### To test: 
http://localhost:4000/session-search/
The data for Rob Withers' poster and the Ken Irwin/Alisa Mizikar/Kristen Peters poster are coming from the speakers.yml file; Ken/Alisa/Kristen have photos from that file; Rob doesn't because he currently hasn't sent one. 

### Going forward:
If we go forward with this approach, we'll need to add the speaker-data to the other poster sessions