### PR TITLE
UPDATE: increase col-md value in speaker figure caption

### DIFF
--- a/_includes/speaker-div.html
+++ b/_includes/speaker-div.html
@@ -19,7 +19,7 @@
                 </ul>
                 {% endif %}
                 <figcaption>
-                    <div class="col-md-8 col-xs-8 text-left">
+                    <div class="col-md-12 col-xs-8 text-left">
                         <h2 class="name">{{ speaker.name }}
                             <span>{{ speaker.surname }}</span></h2>
                         <div class="clearfix"></div>


### PR DESCRIPTION
After increase the `col-` value of the speaker figure captions, all presenter names fit without floating above the card baseline. Below is an 'after increase' example using `Pamela Espinosa de los Monteros`
<img width="348" alt="Screen Shot 2020-08-30 at 5 12 01 PM" src="https://user-images.githubusercontent.com/10561752/91669633-4a681680-eae4-11ea-85f4-efba31f931cc.png">
<img width="344" alt="Screen Shot 2020-08-30 at 5 12 07 PM" src="https://user-images.githubusercontent.com/10561752/91669635-4e943400-eae4-11ea-9f7a-4bcd26d60e37.png">
Closes #179 

