### PR TITLE
UPDATE: truncate biographies at 20 words

### DIFF
--- a/_includes/speaker-div.html
+++ b/_includes/speaker-div.html
@@ -36,7 +36,7 @@
                     </a>
                     {% endfor %}
                 </figcaption>
-                <p class="bio">{{ speaker.bio | strip_html }}</p>
+                <p class="bio">{{ speaker.bio | strip_html | truncatewords: 20, " ..." }}</p>
             </figure>
         </div>
     </div>


### PR DESCRIPTION
This PR truncates the display of a speaker's biography at 20 words on their card. At 20 words, an ellipsis is introduced. Clicking on the card will display the entire biography. Example below.
<img width="340" alt="Screen Shot 2020-08-30 at 5 22 53 PM" src="https://user-images.githubusercontent.com/10561752/91669794-cf9ffb00-eae5-11ea-9e70-06f1e6ffd36a.png">
Closes #180 