### PR TITLE
Adds Thursday Night Social to Schedule

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -61,6 +61,11 @@
         endTime: "4:30",
         sessionIds: [119, 110]
     }
+    - {
+      startTime: "7:00",
+      endTime: "9:00",
+      sessionIds: [203]
+    }
 
 
 - date: "2020-10-30"

--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -401,3 +401,11 @@
   subtype: social
   service: true
   description:
+
+- id: 203
+  title: "🎉 Thursday Night Social"
+  place: "Zoom"
+  subtype: social
+  description: "Join your colleagues for some light-hearted trivia"
+  live-stream-type: social
+  live-stream-link: "https://www.example.com"

--- a/_includes/sessions-modals.html
+++ b/_includes/sessions-modals.html
@@ -82,11 +82,13 @@
 					</div>
 					<div id="session-sponsors" class="modal-sponsors">
 						{% if session.subtype == "keynote" %}
-						{% assign sponsorType = "Keynote" %}
+							{% assign sponsorType = "Keynote" %}
+							{% include sponsors-per-session.html sessionType=sponsorType %}
 						{% elsif session.subtype == "session" %}
-						{% assign sponsorType = "Sessions" %}
+							{% assign sponsorType = "Sessions" %}
+							{% include sponsors-per-session.html sessionType=sponsorType %}
+						{% elsif session.subtype == "social" %}
 						{% endif %}
-						{% include sponsors-per-session.html sessionType=sponsorType %}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
This PR:
- Adds Thursday Night Social to the schedule grid
- Teaches `sessions-modals.html` to identify the subtype of `social` and to not display sponsors for any sessions of this subtype

Closes #194 