### PR TITLE
Adds New Members Session to Schedule

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -19,6 +19,11 @@
       endTime: "4:30",
       sessionIds: [003]
     }
+    - {
+      startTime: "7:00",
+      endTime: "8:00",
+      sessionIds: [004]
+    }
 
 - date: "2020-10-29"
   dateReadable: "October 29"

--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -44,6 +44,14 @@
   live-stream-time: "2020-10-28 15:30:00"
   live-stream-link: "https://www.example.com"
 
+- id: 004
+  title: "New Members Night 👋"
+  description: "Session for members new to ALAO"
+  subtype: social
+  live-stream-type: social
+  live-stream-time:
+  live-stream-link: "https://www.example.com"
+
 # ---------------------------------
 # CONFERENCE DAY[1], prefix ID 10x
 # Increment session IDs by 1


### PR DESCRIPTION
This PR:
- Adds a new members session to the Wednesday evening slot on the conference schedule
<img width="869" alt="Screen Shot 2020-09-05 at 5 24 52 PM" src="https://user-images.githubusercontent.com/10561752/92313730-e68a9580-ef9c-11ea-9aa0-8261b37e5d6c.png">

Following up with Maureen for the exact description that needs to be included. Closes #193 