### PR TITLE
Adds IG Breakfast and Lunch Sessions to Schedule Grid

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -15,9 +15,9 @@
         sessionIds: [002]
     }
     - {
-      startTime: "3:30",
-      endTime: "4:30",
-      sessionIds: [003]
+        startTime: "3:30",
+        endTime: "4:30",
+        sessionIds: [003]
     }
 
 - date: "2020-10-29"
@@ -42,9 +42,9 @@
         sessionIds: [107, 118]
     }
     - {
-      startTime: "12:10",
-      endTime: "1:10",
-      sessionIds: [122]
+        startTime: "12:10",
+        endTime: "1:10",
+        sessionIds: [122]
     }
     - {
         startTime: "1:10",
@@ -70,6 +70,11 @@
     - {title: "Track #2"}
   timeslots:
     - {
+        startTime: "8:00",
+        endTime: "8:50",
+        sessionIds: [204, 205]
+    }
+    - {
         startTime: "9:00",
         endTime: "10:00",
         sessionIds: [109, 103]
@@ -85,9 +90,9 @@
         sessionIds: [106, 116]
     }
     - {
-      startTime: "12:20",
-      endTime: "1:20",
-      sessionIds: [202]
+        startTime: "12:20",
+        endTime: "1:20",
+        sessionIds: [206, 207, 202]
     }
     - {
         startTime: "1:20",
@@ -100,7 +105,7 @@
         sessionIds: [111, 104]
     }
     - {
-      startTime: "3:40",
-      endTime: "4:30",
-      sessionIds: [201]
+        startTime: "3:40",
+        endTime: "4:30",
+        sessionIds: [201]
     }

--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -401,3 +401,43 @@
   subtype: social
   service: true
   description:
+
+- id: 204
+  title: "Sustainability Interest Group (SUSIG)"
+  subtype: social
+  description: "<br/><strong>How are you being more sustainable at your library during the pandemic?</strong><br/>Join ALAO keynote speaker Rebekkah Smith Aldrich and the Sustainability Interest Group for an opportunity to ask questions, share experiences, and discuss the role of sustainability in academic libraries. We will explore ways in which our libraries have been more sustainable during the pandemic, and what we can do as academic librarians to contribute to sustainability efforts going forward."
+  handouts:
+  video:
+  live-stream-type: social
+  live-stream-time:
+  live-stream-link: "https://www.example.com"
+
+- id: 205
+  title: "STEM Interest Group (STEMIG)"
+  subtype: social
+  description: "<br/><strong>STEM Librarianship During the Pandemic</strong><br/>Librarians supporting STEM research and education face unique challenges (and maybe opportunities) in the post-COVID-19 world. Join STEMIG to discuss how the pandemic has changed the way we work."
+  handouts:
+  video:
+  live-stream-type: social
+  live-stream-time:
+  live-stream-link: "https://www.example.com"
+
+- id: 206
+  title: "Instruction Interest Group (IIG)"
+  subtype: social
+  description: "<br/><strong>Keeping Students Engaged: Information Literacy Instruction in a Virtual Environment</strong><br/>Join the Instruction Interest Group’s lunchtime roundtable to discuss instruction techniques that keep students engaged in both synchronous and asynchronous virtual learning environments."
+  handouts:
+  video:
+  live-stream-type: social
+  live-stream-time:
+  live-stream-link: "https://www.example.com"
+
+- id: 207
+  title: "Special Collections and Archives Interest Group (SCAIG)"
+  subtype: social
+  description: "<br/><strong>Special Collections, Archives, and Extraordinary Circumstances</strong><br/>Discussion on how the fall is progressing for special collections and archives professionals in the time of COVID-19: what was planned, what’s changed, and other new challenges and successes."
+  handouts:
+  video:
+  live-stream-type: social
+  live-stream-time:
+  live-stream-link: "https://www.example.com"

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -43,8 +43,9 @@
         <div class="timeslot-elements flexbox-wrapper">
           {% for slot in timeslot.sessionIds %} {% assign slotColWidth = 12 |
           divided_by: forloop.length %} {% assign slotIndex = forloop.index0 %}
-          {% if slot != 404 %} {% for session in site.data.sessions %} {% if
-          slot == session.id and session.service == null %}
+          {% if slot != 404 %}
+          {% for session in site.data.sessions %}
+          {% if slot == session.id and session.service == null %}
           <div id="session-{{ session.id }}"
             class="slot col-md-{{ slotColWidth }} col-xs-12 flexbox-item-height"
             data-slot-detail="{{ day.tracks[slotIndex].title }}"


### PR DESCRIPTION
**To test:** confirm that the four (4) IG sessions on the schedule grid open modals with the interest group's discussion topic and button to launch a Zoom session.

We may need to enhance this PR (i.e. functionality) at a later time. For the moment, I want to ensure that we have something basic in place for this conference cycle.

Closes #177 