### PR TITLE
Adds Nondescript Default Photo to Entries on Session Search Interface 

### DIFF
--- a/_includes/session-search.html
+++ b/_includes/session-search.html
@@ -75,7 +75,7 @@
           {% endcomment %}
           {% for id in session.speaker-data %}
           {% assign this-person = site.data.speakers | where: 'id', id %}
-          {% if this-person[0].thumbnailUrl != "no_image.png" %}
+          {% if this-person[0].thumbnailUrl %}
           {% assign speakers = speakers |
             append: '<div class="speaker-block"><div class="speaker-img flow-img img-circle" style="background-image: url(/img/people/'  | append: this-person[0].thumbnailUrl |append:')"></div> 
             <p class="speaker-name"><span class="name-only">' | append: this-person[0].name | append: ' ' | append: this-person[0].surname | append: '</span><span class="speaker-position">' | append: this-person[0].company | append: '</span


### PR DESCRIPTION
Example Below:

<img width="1066" alt="Screen Shot 2020-09-13 at 4 31 27 PM" src="https://user-images.githubusercontent.com/10561752/93027974-abace100-f5de-11ea-9283-9011ad4e5b42.png">

Closes #210 