### PR TITLE
Adds Logic to Toggle the View Poster Button Based Upon showPosters in config.yml

### DIFF
--- a/_includes/posters-modals.html
+++ b/_includes/posters-modals.html
@@ -23,7 +23,9 @@
             <p class="poster-description">
               {{ page.description }}
             </p>
-            <a href="/posters/{{page.slug}}.html" class="btn btn-primary">View Poster</a>
+            {% if site.showPosters != false %}
+              <a href="/posters/{{page.slug}}.html" class="btn btn-primary">View Poster</a>
+            {% endif %}
             <div class="people-details">
               {% if page.speaker-data %}
               {% for id in page.speaker-data %}


### PR DESCRIPTION
To Test:
- toggle the boolean `showPosters` in `config.yml`. When the value of showPosters is False, the 'View Poster' button should not display in the poster modals.

Closes #212 