### PR TITLE
Issue#187

### DIFF
--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -126,6 +126,7 @@
                 Some questions that tend to arise in other disciplinary areas involve traditional business research areas, particularly company and industry research.  Many other questions arise from a growing trend, both in academia and society at large, towards entrepreneurship and/or an ‘entrepreneurial mindset’, wherein patrons might be considering more nuanced questions predominantly related to market research.  Attendees at this presentation will learn some of the more common cross-discipline business research foundations, tips and tricks."
   subtype: session
   speakers: [29]
+  additional_support: 'EBSCO'
   language:
   complexity:
   handouts:
@@ -188,6 +189,7 @@
     Attendees of this presentation will come away with ideas of how best to partner with and build on relationships with other offices at their institutions and take away multiple plans for demonstrating the value of the library in a purely online environment."
   subtype: session
   speakers: [65, 70]
+  additional_support: 'Wall Street Journal'
   language:
   complexity:
   handouts:
@@ -227,6 +229,7 @@
   description: "Data literacy (DL) is an important topic that is not typically covered in-depth as part of undergraduate curricula, yet is often a skillset that faculty expect new graduate students to have. In spring 2020, librarians partnered with a STEM department to transform its in-person DL workshops. Online modules were created to cover four main DL subjects: data management, data curation, data analysis, and data visualization. The modules were designed to either be standalone or taken together as a microcredential, and to be applicable to a wide range of disciplines. Over the summer, several graduate students, faculty, and librarians were recruited to test and provide feedback on the modules, with the goal of a full rollout in fall 2020. Many faculty have already expressed interest in incorporating one or more of these modules into their online courses. Future developments will strengthen the library’s remote instruction offerings to face challenges posed by uncertain times and ensure students are able to cultivate these skills. This presentation will cover the development of these modules, including outreach and marketing efforts, and will provide a platform for attendees to identify, discuss, and plan how they might incorporate data literacy instruction at their institutions."
   subtype: session
   speakers: [12, 6]
+  additional_support: 'GeoScienceWorld'
   language:
   complexity:
   handouts:
@@ -267,6 +270,7 @@
   description: "COVID-19 forced us all to face realities of closed buildings, precarious employment situations, and challenges to our well-being. This presentation will showcase how our resilience depended on people, not buildings. A team of librarians and communicators will share three pandemic-era strategies developed to put people at the forefront of initiatives and messaging. A revamped marketing strategy for our research appointment service puts faces to the work and student support, instead of listing the menu of what people can get out of it. Reporting numbers and stories to the provost prompted us to center the focus on how the workers made it possible, despite the unpredictable circumstances. The cancellation announcement of a beloved annual event centered on how the event takes months of planning by employees — some of whom were affected by university furloughs and layoffs. By intentionally bringing attention to the human component of library work, we were able to share our commitment to service while also setting boundaries, sharing our limitations and tempering our need, as author/librarian Fobazi Ettarh would say, to satisfy our vocational awe. Presenters will prompt you to consider how you frame what library workers do, versus what an inanimate building offers."
   subtype: session
   speakers: [44, 9, 74, 64]
+  additional_support: 'Ohio Library Support Staff Institute'
   language:
   complexity:
   handouts:
@@ -310,6 +314,7 @@
     This presentation will explore the opportunities and challenges presented by actively building a crowdsourced collection, and how the speakers minimized risks in its creation and preservation. Though the presentation will be framed around the experiences of a single institution, attendees will leave equipped with the knowledge to develop a community-born archival collection. Attendees will also learn how to address preservation challenges working with archival collections that will be sealed for a significant amount of time."
   subtype: session
   speakers: [46, 39, 43, 54]
+  additional_support: 'HF Group'
   language:
   complexity:
   handouts:
@@ -371,6 +376,7 @@
                 This presentation will discuss the design and methodology used to create the initiative, training, and implementation as well as discuss the workshop outcome and its effectiveness in developing strategic EDI actions for the organization. The presentation will also provide a method from which to cultivate in-house EDI leaders who can lead from where they are."
   subtype: session
   speakers: [28, 76]
+  additional_support: 'Springer Nature'
   language:
   complexity:
   handouts:

--- a/_includes/sponsors-per-session.html
+++ b/_includes/sponsors-per-session.html
@@ -10,6 +10,7 @@
     padding-bottom: 5px;
   }
 </style>
+
 <div class="row">
   {% for sponsor in site.data.sponsors %}
   {% if sponsor.group == 'Gold' or sponsor.group == include.sessionType %}
@@ -29,4 +30,28 @@
   </div>
   {% endif %}
   {% endfor %}
+
+  {% if session.additional_support %}
+  {% for sponsor in site.data.sponsors %}
+    {% if sponsor.group == 'Additional Support' %}
+      <div class="sponsorGroupWrapper">
+        <div class="h3">{{ sponsor.group }}</div>
+        <ul class="list-inline">
+          {% for element in sponsor.elements %}
+            {% if element.name == session.additional_support %}
+            <li>
+              <a href="{{ element.link }}" target="_blank">
+                <img src="{{ site.baseurl }}/img/sponsors/{{ element.imageUrl }}"
+                  title="{{ element.description }}" alt="{{ element.name }}"
+                  style="width:100%" />
+              </a>
+            </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+  {% endfor %}
+  {% endif %}
+
 </div>


### PR DESCRIPTION
This PR:
- Adds a new value to session objects called `additional_support`
- Adds logic into `sponsors-per-session.yml` to write additional support logos into session modals

To Test:
- Has Additional Support http://127.0.0.1:4000/session-search/#session-117
- Does Not Have Additional Support http://127.0.0.1:4000/session-search/#session-116

Closes #187 