### PR TITLE
Enable Conference Hashtag Section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -384,7 +384,7 @@ ticketsOffers:
 # -------------------------------------------------------------
 # Tweets Feed Block
 # -------------------------------------------------------------
-tweetsFeedEnable: false
+tweetsFeedEnable: true
 tweetsFeedImage: "katy.jpg"
 tweetsFeedTitle: "What's Up?"
 twitterHashTag: "alao2020"


### PR DESCRIPTION
This PR:
- Enables the display of the conference hashtag as a section on the main conference page.

To Test:
- Scroll until just above the registration section and you'll see the conference hashtag section.

Closes #226 