### PR TITLE
Display 'Session Feedback' Button on Sessions Only 

### DIFF
--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -34,7 +34,7 @@
 - id: 003
   title: "From Being To Doing: Anti-racism as Action at Work"
   description: "Over the past few years, the conversation around equity in libraries has focused on thinking of the word ally as a verb, rather than as an identity. With recent events highlighting specific issues around race, the conversation has now shifted to many people wanting to be anti-racist. In this session, we will focus on anti-racism as action, rather than using the word anti-racist as identity. In particular, we will examine our notions of professionalism in libraries. Can changing how we define professionalism in library workplaces be an example of anti-racist action? We will take a critical look at how certain hallmarks of white supremacist culture inform our notions of professionalism and acceptable workplace culture. These commonly accepted traits can actually contribute to low morale, the prevalence of microaggressions, retention issues, etc. Together, we will explore ways to transform our workplace cultures by looking at specific actions that resist these hallmarks in order to create equitable workplaces."
-  subtype: workshop
+  subtype: session
   speakers: [5]
   language:
   complexity:

--- a/_includes/sessions-modals.html
+++ b/_includes/sessions-modals.html
@@ -34,12 +34,14 @@
 					</div>
 					{% endif %}
 					<p class="theme-description">{{ session.description }}</p>
+					{% if session.subtype == 'session' %}
 					<div class="row survey-row">
 						<div class="col-md-4"></div>
 						<div class="col-md-8">
 							<a href="{{ site.sessionFeedbackForm }}&{{ site.sessionFeedbackParameter }}={{ session.title | url_encode }}" class="survey-button btn" aria-label="Complete the session survey for {{ session.title }}}">Session Feedback</a>
 						</div>
 					</div>
+					{% endif %}
 					<div class="row qa-row">
 						<div class="col-md-4">
 							{% if session.handouts %}


### PR DESCRIPTION
This PR adds some logic to only display the 'Session Feedback' button when `session.subtype` is `session`.

Closes #239 