### PR TITLE
Poster additional support

### DIFF
--- a/_includes/poster.html
+++ b/_includes/poster.html
@@ -53,7 +53,10 @@
                 {% elsif doc.type == 'iframe' %}
                 <div class="poster-iframe">
                   <h4 class="h5">{{doc.title}}</h4>
-                  <iframe width="{{doc.width}}" height="{{doc.height}}" allowfullscreen="true" frameborder="0" mozallowfullscreen="true" src="{{doc.url}}" title="{{doc.title}}" webkitallowfullscreen="true"></iframe>
+                  <iframe width="{{doc.width}}" height="{{doc.height}}"
+                    allowfullscreen="true" frameborder="0"
+                    mozallowfullscreen="true" src="{{doc.url}}"
+                    title="{{doc.title}}" webkitallowfullscreen="true"></iframe>
                 </div>
                 {% endif %}
               </div>
@@ -116,7 +119,7 @@
       </div>
       <div class="col-lg-3 col-lg-offset-1 col-md-2 col-xs-12"
         id="poster-sponsors">
-        {% include sponsors-per-session.html sessionType='Posters' %}
+        {% include sponsors-per-session.html sessionType='Posters' additional_support=page.additional_support %}
       </div>
     </div>
   </div>

--- a/_includes/sponsors-per-session.html
+++ b/_includes/sponsors-per-session.html
@@ -27,7 +27,8 @@
         {% if element.video %}
         <div class="sponsors video-container">
           <div class="sponsors video-modals">
-            <a href="{{ element.video }}" aria-label='Sponsor video for {{ element.name }}'>
+            <a href="{{ element.video }}"
+              aria-label='Sponsor video for {{ element.name }}'>
               <i class="fa fa-youtube-play fa-lg sponsors video-link"></i>
             </a>
           </div>
@@ -40,35 +41,36 @@
   {% endif %}
   {% endfor %}
 
-  {% if session.additional_support %}
+  {% if session.additional_support or include.additional_support != nil %}
   {% for sponsor in site.data.sponsors %}
-    {% if sponsor.group == 'Additional Support' %}
-      <div class="sponsorGroupWrapper">
-        <div class="h3">{{ sponsor.group }}</div>
-        <ul class="list-inline">
-          {% for element in sponsor.elements %}
-            {% if element.name == session.additional_support %}
-            <li>
-              <a href="{{ element.link }}" target="_blank">
-                <img src="{{ site.baseurl }}/img/sponsors/{{ element.imageUrl }}"
-                  title="{{ element.description }}" alt="{{ element.name }}"
-                  style="width:100%" />
-              </a>
-              {% if element.video %}
-              <div class="sponsors video-container">
-                <div class="sponsors video-modals">
-                  <a href="{{ element.video }}" aria-label='Sponsor video for {{ element.name }}'>
-                    <i class="fa fa-youtube-play fa-lg sponsors video-link"></i>
-                  </a>
-                </div>
-              </div>
-              {% endif %}
-            </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
-    {% endif %}
+  {% if sponsor.group == 'Additional Support' %}
+  <div class="sponsorGroupWrapper">
+    <div class="h3">{{ sponsor.group }}</div>
+    <ul class="list-inline">
+      {% for element in sponsor.elements %}
+      {% if element.name == session.additional_support or element.name == include.additional_support %}
+      <li>
+        <a href="{{ element.link }}" target="_blank">
+          <img src="{{ site.baseurl }}/img/sponsors/{{ element.imageUrl }}"
+            title="{{ element.description }}" alt="{{ element.name }}"
+            style="width:100%" />
+        </a>
+        {% if element.video %}
+        <div class="sponsors video-container">
+          <div class="sponsors video-modals">
+            <a href="{{ element.video }}"
+              aria-label='Sponsor video for {{ element.name }}'>
+              <i class="fa fa-youtube-play fa-lg sponsors video-link"></i>
+            </a>
+          </div>
+        </div>
+        {% endif %}
+      </li>
+      {% endif %}
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
   {% endfor %}
   {% endif %}
 

--- a/_posts/2020-07-01-bracketology.md
+++ b/_posts/2020-07-01-bracketology.md
@@ -4,6 +4,7 @@ title: "June Madness! A Month of Book Bracketology"
 description: "Offering support in a remote learning environment has long been an essential function of libraries. As universities across the country moved to digital spaces for engagement as well as education, libraries followed suit. June Madness! is a piece of passive programming offered by this academic library. Utilizing both Libwizard and Libguides, librarians were able to create a program which mirrored the traditional NCAA March Madness Bracket, using books from the library and OhioLINK catalogs to represent four areas unique to this campus. June Madness! offered students the opportunity to interact with their library, voice their opinions, and predict winners on their own time, allowing them to learn about lending services at their own pace. Coordinated marketing of the program to university faculty, staff, alumni, and students showcased the library as a digital space not only for distance learning, but for fun and engagement as well."
 date: 2020-07-01 08:00:00
 speaker-data: [45, 71, 32]
+additional_support: "Emery Pratt"
 presenters:
   - {
       name: Zachary Lewis,


### PR DESCRIPTION
* adds support for "additional_support" option on posters
* adds Emery Pratt as additional_support in Bracketology poster
* closes #284 

## To Test: 
* [Bracketology poster](http://localhost:4000/posters/bracketology) should show Emery Pratt logo under additional support in sponsor section
* Other posters (e.g. http://localhost:4000/posters/art-design ) should not show an additional support section