### PR TITLE
applied github icon to "no login needed" link

### DIFF
--- a/_posts/2020-07-01-no-login-needed.md
+++ b/_posts/2020-07-01-no-login-needed.md
@@ -26,7 +26,7 @@ supplemental-docs:
   - type: pdf
     url: /handouts/deems_slides.pdf
     title: Poster Slides as PDF
-  - type: website
+  - type: github
     url: https://github.com/c-deems/hml_website
     title: Code
 isStaticPost: false


### PR DESCRIPTION
one of the poster types available is "github" but it didn't get used on this poster; I update the metadata to gett the GH icon instead of a standard link icon